### PR TITLE
fix: correct CLI facts against current opencode docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ A Claude Code skill for headless LLM automation using the OpenCode CLI.
 
 ## Overview
 
-This skill provides Claude with comprehensive knowledge about the [OpenCode CLI](https://opencode.ai), a Go-based tool that provides access to 75+ LLM providers through a unified interface. The skill focuses on the headless `run` command for automation and subprocess integration.
+This skill provides Claude with comprehensive knowledge about the [OpenCode CLI](https://opencode.ai), a TypeScript/Bun-based tool that provides access to many LLM providers through a unified interface. The skill focuses on the headless `run` command for automation and subprocess integration.
 
 ## Features
 
@@ -105,11 +105,11 @@ opencode run --model <provider/model> "<prompt>"
 
 ### Configuration Locations
 
-Configuration files are searched in the following order (project settings override global):
+Configuration files are **merged** and loaded in the following precedence order (later overrides earlier):
 
-1. **Environment Variable**: `OPENCODE_CONFIG` path
-2. **Project-Level**: `opencode.json` in project root
-3. **Global**: `~/.config/opencode/opencode.json`
+1. **Global**: `~/.config/opencode/opencode.json`
+2. **Environment Variable**: `OPENCODE_CONFIG` path
+3. **Project-Level**: `opencode.json` in project root (highest standard config)
 
 ## Project Structure
 
@@ -131,8 +131,9 @@ opencode_cli/
 | Feature | OpenCode | Claude CLI |
 |---------|----------|------------|
 | Headless mode | `run` subcommand | `-p` flag with stdin |
-| Hooks support | No | Yes |
-| Directory access | No | Yes (`--add-dir`) |
+| Model format | `provider/model` | Short names (sonnet, opus) |
+| Permissions/pre-approval | `permission` config + `run --auto` | `--allowedTools` flag |
+| Machine-readable output | `run --format json` | `--output-format` |
 | Prompt input | Positional argument | Stdin or `-p` |
 
 ## License

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: opencode-cli
-description: This skill should be used when configuring or using the OpenCode CLI for headless LLM automation. Use when the user asks to "configure opencode", "use opencode cli", "set up opencode", "opencode run command", "opencode model selection", "opencode providers", "opencode vertex ai", "opencode mcp servers", "opencode ollama", "opencode local models", "opencode deepseek", "opencode kimi", "opencode mistral", "fallback cli tool", or "headless llm cli". Covers command syntax, provider configuration, Vertex AI setup, MCP servers, local models, cloud providers, and subprocess integration patterns.
+description: This skill should be used when configuring or using the OpenCode CLI for headless LLM automation. Use when the user asks to "configure opencode", "use opencode cli", "set up opencode", "opencode run command", "opencode model selection", "opencode providers", "opencode vertex ai", "opencode mcp servers", "opencode ollama", "opencode local models", "opencode deepseek", "opencode kimi", "opencode mistral", "opencode serve", "opencode auth login", "headless llm cli", or "fallback cli tool". Covers command syntax, provider configuration, Vertex AI setup, MCP servers, local models, cloud providers, and subprocess integration patterns. The canonical source of truth is https://opencode.ai/docs.
 ---
 
 # OpenCode CLI Skill
@@ -15,20 +15,20 @@ Use OpenCode CLI for headless LLM automation via subprocess invocation.
 - [Model Format](#model-format)
 - [Configuration](#configuration)
 - [Reference Guides](#reference-guides)
+- [Vertex AI Setup](#vertex-ai-setup)
 - [Subprocess Invocation](#subprocess-invocation)
-- [Limitations vs Claude CLI](#limitations-vs-claude-cli)
+- [Features vs Claude CLI](#features-vs-claude-cli)
 - [Environment Variables](#environment-variables)
 - [Verify Setup](#verify-setup)
 - [Best Practices](#best-practices)
 
 ## Quick Start
 
-1. Install OpenCode CLI (see [OpenCode documentation](https://opencode.ai))
-2. Set environment variables for the provider:
+1. Install OpenCode CLI (see [OpenCode documentation](https://opencode.ai/docs)). On Windows: `npm install -g opencode-ai`, `choco install opencode`, or `scoop install opencode`; WSL is recommended.
+2. Authenticate with a provider:
    ```bash
-   export ANTHROPIC_API_KEY="sk-..."  # For Anthropic
-   # OR
-   export GOOGLE_CLOUD_PROJECT="project-id"  # For Vertex AI
+   opencode auth login        # stores in ~/.local/share/opencode/auth.json
+   # OR set env vars, e.g. ANTHROPIC_API_KEY / GOOGLE_CLOUD_PROJECT for Vertex AI
    ```
 3. Verify installation:
    ```bash
@@ -41,7 +41,7 @@ Use OpenCode CLI for headless LLM automation via subprocess invocation.
 
 ## Overview
 
-OpenCode is a Go-based CLI that provides access to 75+ LLM providers through a unified interface. This skill focuses on the headless `run` command for automation and subprocess integration.
+OpenCode is a TypeScript/Bun-based CLI that provides access to many LLM providers through a unified interface. This skill focuses on the headless `run` command for automation and subprocess integration.
 
 ## Basic Usage
 
@@ -53,21 +53,25 @@ opencode run --model <provider/model> "<prompt>"
 
 **Key points:**
 - Use `run` subcommand for headless (non-interactive) mode
-- Model format is always `provider/model`
+- Model format is always `provider/model`, set via `-m`/`--model`
 - Prompt is a positional argument at the end
-- No stdin support (unlike Claude CLI's `-p` flag)
+- Add `--format json` for machine-readable output
+- Use `opencode serve` + `opencode run --attach <url>` to reuse a warm server
 
 ### Examples
 
 ```bash
 # Using Anthropic Claude
-opencode run --model anthropic/claude-sonnet-4-20250514 "Explain this code"
+opencode run --model anthropic/claude-sonnet-4-5 "Explain this code"
 
 # Using Google Gemini
 opencode run --model google/gemini-2.5-pro "Review this architecture"
 
-# Using free Grok tier
-opencode run --model opencode/grok-code "Generate tests for this function"
+# Using the configured default model
+opencode run "Generate tests for this function"
+
+# JSON output for scripting
+opencode run --format json --model openai/gpt-4o-mini "Short summary"
 ```
 
 ## Model Format
@@ -76,21 +80,29 @@ Models use the pattern `provider/model-name`:
 
 | Provider | Example Model |
 |----------|---------------|
-| `anthropic` | `anthropic/claude-sonnet-4-20250514` |
+| `anthropic` | `anthropic/claude-sonnet-4-5` |
 | `google` | `google/gemini-2.5-pro` |
-| `opencode` | `opencode/grok-code` (free tier) |
 | `openai` | `openai/gpt-4o` |
 | `google-vertex` | `google-vertex/gemini-2.5-pro` |
+| `ollama` | `ollama/llama3.2` (local) |
+
+List available models with `opencode models [provider]` (add `--refresh` to update the cache).
 
 ## Configuration
 
 ### Config File Locations
 
-1. **Environment variable**: `OPENCODE_CONFIG` path
-2. **Project-level**: `opencode.json` in project root
-3. **Global**: `~/.config/opencode/opencode.json`
+Config files are **merged** (not replaced); later sources override earlier ones for conflicting keys. Effective order (lowest to highest):
 
-Configs are merged (project overrides global).
+1. **Remote config** — organizational defaults from `.well-known/opencode`
+2. **Global**: `~/.config/opencode/opencode.json`
+3. **Custom path**: `OPENCODE_CONFIG` env var
+4. **Project**: `opencode.json` in project root
+5. `.opencode/` directories (agents, commands, plugins)
+6. **Inline**: `OPENCODE_CONFIG_CONTENT` env var
+7. **Managed** (admin-controlled, not user-overridable)
+
+In practice: project config overrides `OPENCODE_CONFIG` overrides global.
 
 ### Basic Configuration
 
@@ -104,7 +116,7 @@ Configs are merged (project overrides global).
 
 ### Authentication
 
-Credentials stored in `~/.local/share/opencode/auth.json` after running `/connect` in TUI mode, or configure via environment variables.
+Run `opencode auth login` for any provider supported by models.dev, or configure via environment variables. Credentials are stored in `~/.local/share/opencode/auth.json`.
 
 ## Reference Guides
 
@@ -141,21 +153,23 @@ output = result.stdout
 
 ### Key Considerations
 
-1. **Stagger parallel calls** - Add 5-10 second delays between parallel invocations to avoid cache race conditions
-2. **Implement fallback** - Consider Claude CLI as fallback if OpenCode fails
-3. **Health check** - Use `opencode --version` to verify availability
-4. **Timeout handling** - Set appropriate timeouts (default 600s for long generations)
+1. **Prefer `--format json`** - Use for stable, machine-readable output
+2. **Use `serve` + `--attach`** - Avoid MCP/provider cold-boot on every invocation
+3. **Implement fallback** - Consider Claude CLI as fallback if OpenCode fails
+4. **Health check** - Use `opencode --version` to verify availability
+5. **Timeout handling** - Set appropriate timeouts (default 600s for long generations)
 
 See [integration-patterns.md](references/integration-patterns.md) for complete patterns.
 
-## Limitations vs Claude CLI
+## Features vs Claude CLI
 
 | Feature | OpenCode | Claude CLI |
 |---------|----------|------------|
 | Headless mode | `run` subcommand | `-p` flag with stdin |
-| Hooks/settings | Not supported | `--settings` flag |
-| Directory access | Not supported | `--add-dir` flag |
-| Tool pre-approval | Not supported | `--allowedTools` flag |
+| Model format | `provider/model` | Short names (sonnet, opus) |
+| Permissions/pre-approval | `permission` config + `run --auto` | `--allowedTools` flag |
+| Session continuation | `run -c` / `run -s <id>` | `--resume` |
+| Machine-readable output | `run --format json` | `--output-format` |
 | Prompt input | Positional argument | Stdin or `-p` |
 
 ## Environment Variables
@@ -163,9 +177,12 @@ See [integration-patterns.md](references/integration-patterns.md) for complete p
 | Variable | Purpose |
 |----------|---------|
 | `OPENCODE_CONFIG` | Custom config file path |
+| `OPENCODE_CONFIG_CONTENT` | Inline JSON config |
+| `OPENCODE_SERVER_PASSWORD` | Basic auth for `serve`/`web` |
 | `GOOGLE_CLOUD_PROJECT` | GCP project for Vertex AI |
 | `GOOGLE_APPLICATION_CREDENTIALS` | Service account JSON path |
-| `VERTEX_LOCATION` | Vertex AI region |
+| `ANTHROPIC_API_KEY` | Anthropic API key |
+| `OPENAI_API_KEY` | OpenAI API key |
 
 ## Verify Setup
 
@@ -179,16 +196,20 @@ Complete this checklist to verify a working installation:
    ```bash
    opencode run --model google/gemini-2.5-pro "Say hello"
    ```
-3. **Check configuration** - Review active config:
+3. **List models** - Review available models:
+   ```bash
+   opencode models [provider]
+   ```
+4. **Check configuration** - Review active config:
    ```bash
    cat ~/.config/opencode/opencode.json
    ```
-4. **Verify MCP servers** (if configured) - Test MCP connectivity by running a command that uses MCP tools
+5. **Verify MCP servers** (if configured) - `opencode mcp list`
 
 ## Best Practices
 
 1. **Use project-level config** - Create `opencode.json` for project-specific settings
-2. **Prefer environment variables** - Use `{env:VAR_NAME}` syntax in config for secrets
+2. **Prefer environment variables** - Use `{env:VAR_NAME}` / `{file:path}` syntax in config for secrets
 3. **Implement retries** - Network failures are common; implement retry logic
 4. **Log output** - Capture both stdout and stderr for debugging
-5. **Stagger parallel calls** - Prevent cache race conditions with delays
+5. **Use `serve` + `--attach`** - Reuse a warm server for repeated/parallel invocations

--- a/references/integration-patterns.md
+++ b/references/integration-patterns.md
@@ -18,6 +18,8 @@ opencode run --model <provider/model> "<prompt>"
 - `--model` - Provider and model in `provider/model` format
 - `prompt` - Positional argument (the actual prompt text)
 
+**For scripting:** add `--format json` for stable, machine-readable output. For repeated invocations, start `opencode serve` once and attach with `opencode run --attach http://localhost:4096` to avoid per-run MCP/provider cold boot.
+
 ## Basic Invocation Pattern
 
 ### Command Building
@@ -188,9 +190,9 @@ args = ["-p"]
 | Headless command | `opencode run` | `claude -p` |
 | Prompt input | Positional arg | Stdin or `-p` flag |
 | Model format | `provider/model` | Short names (sonnet, opus) |
-| Hooks support | No | Yes (`--settings`) |
-| Directory access | No | Yes (`--add-dir`) |
-| Tool pre-approval | No | Yes (`--allowedTools`) |
+| Permissions/pre-approval | `permission` config + `run --auto` | `--allowedTools` |
+| Machine-readable output | `run --format json` | `--output-format` |
+| Session continuation | `run -c` / `run -s <id>` | `--resume` |
 
 ## Best Practices Summary
 

--- a/references/local-models.md
+++ b/references/local-models.md
@@ -32,7 +32,7 @@ ollama pull mistral:latest
 
 ```json
 {
-  "$schema": "https://opencode.dev/schema/opencode.json",
+  "$schema": "https://opencode.ai/config.json",
   "model": "ollama/qwen3-coder:latest",
   "provider": {
     "ollama": {

--- a/references/mcp-servers.md
+++ b/references/mcp-servers.md
@@ -8,7 +8,7 @@ Add MCP servers in `opencode.json`:
 
 ```json
 {
-  "$schema": "https://opencode.dev/schema/opencode.json",
+  "$schema": "https://opencode.ai/config.json",
   "mcp": {
     "server-name": {
       "type": "local",
@@ -20,11 +20,66 @@ Add MCP servers in `opencode.json`:
 }
 ```
 
+## Server Types
+
+| Type | Description |
+|------|-------------|
+| `local` | Run as a local subprocess |
+| `remote` | Connect to a remote URL (supports OAuth) |
+
+### Local Server Options
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `type` | Yes | Must be `"local"` |
+| `command` | Yes | Command array to execute |
+| `cwd` | No | Working directory for the process |
+| `environment` | No | Environment variables |
+| `enabled` | No | Enable/disable on startup (default true) |
+| `timeout` | No | Tool-fetch timeout in ms (default 5000) |
+
+### Remote Server Options
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `type` | Yes | Must be `"remote"` |
+| `url` | Yes | Remote MCP server URL |
+| `headers` | No | Headers (e.g. `Authorization`) |
+| `oauth` | No | OAuth config, or `false` to disable auto-OAuth |
+| `enabled` | No | Enable/disable on startup |
+
 ## Common MCP Servers
 
-### Brave Search
+### Context7 (Documentation Lookup) — Remote (recommended)
 
-Web search capability:
+```json
+{
+  "mcp": {
+    "context7": {
+      "type": "remote",
+      "url": "https://mcp.context7.com/mcp"
+    }
+  }
+}
+```
+
+With an optional API key for higher rate limits:
+
+```json
+{
+  "mcp": {
+    "context7": {
+      "type": "remote",
+      "url": "https://mcp.context7.com/mcp",
+      "headers": {
+        "CONTEXT7_API_KEY": "{env:CONTEXT7_API_KEY}"
+      }
+    }
+  }
+}
+```
+
+### Brave Search
 
 ```json
 {
@@ -43,69 +98,7 @@ Web search capability:
 
 **Get API key:** https://brave.com/search/api/
 
-### Context7 (Documentation Lookup)
-
-Library documentation access:
-
-```json
-{
-  "mcp": {
-    "context7": {
-      "type": "local",
-      "command": ["npx", "-y", "@upstash/context7-mcp"],
-      "enabled": true
-    }
-  }
-}
-```
-
-No API key required.
-
-### Perplexity Ask
-
-AI-powered search:
-
-```json
-{
-  "mcp": {
-    "perplexity-ask": {
-      "type": "local",
-      "command": ["npx", "-y", "server-perplexity-ask"],
-      "enabled": true,
-      "environment": {
-        "PERPLEXITY_API_KEY": "{env:PERPLEXITY_API_KEY}"
-      }
-    }
-  }
-}
-```
-
-**Get API key:** https://www.perplexity.ai/settings/api
-
-### Notion API
-
-Notion workspace access:
-
-```json
-{
-  "mcp": {
-    "notionApi": {
-      "type": "local",
-      "command": ["npx", "-y", "@notionhq/notion-mcp-server"],
-      "enabled": true,
-      "environment": {
-        "OPENAPI_MCP_HEADERS": "{\"Authorization\": \"Bearer {env:NOTION_API_KEY}\", \"Notion-Version\": \"2022-06-28\"}"
-      }
-    }
-  }
-}
-```
-
-**Get API key:** https://www.notion.so/my-integrations
-
 ### GitHub
-
-Repository access:
 
 ```json
 {
@@ -122,9 +115,9 @@ Repository access:
 }
 ```
 
-### Filesystem
+**Note:** The GitHub MCP server adds a lot of tokens to the context; disable when not needed.
 
-Local file access:
+### Filesystem
 
 ```json
 {
@@ -132,7 +125,7 @@ Local file access:
     "filesystem": {
       "type": "local",
       "command": [
-        "npx", "-y", "@anthropic-ai/mcp-server-filesystem",
+        "npx", "-y", "@modelcontextprotocol/server-filesystem",
         "/path/to/allowed/directory"
       ],
       "enabled": true
@@ -141,68 +134,39 @@ Local file access:
 }
 ```
 
-### Sequential Thinking
-
-Chain-of-thought reasoning:
+### Sequential Thinking / Memory
 
 ```json
 {
   "mcp": {
     "sequential-thinking": {
       "type": "local",
-      "command": ["npx", "-y", "@anthropic-ai/mcp-server-sequential-thinking"],
+      "command": ["npx", "-y", "@modelcontextprotocol/server-sequential-thinking"],
       "enabled": true
-    }
-  }
-}
-```
-
-### Memory
-
-Persistent memory across sessions:
-
-```json
-{
-  "mcp": {
+    },
     "memory": {
       "type": "local",
-      "command": ["npx", "-y", "@anthropic-ai/mcp-server-memory"],
+      "command": ["npx", "-y", "@modelcontextprotocol/server-memory"],
       "enabled": true
     }
   }
 }
 ```
 
-## Configuration Options
+> **Package names:** The official reference servers are published under the `@modelcontextprotocol/*` scope. Older `@anthropic-ai/mcp-server-*` names are deprecated — verify current package names with `npm view <package>` before relying on them.
 
-### Server Types
+## CLI Management
 
-| Type | Description |
-|------|-------------|
-| `local` | Run as local subprocess |
-| `remote` | Connect to remote server |
-
-### Common Fields
-
-```json
-{
-  "server-name": {
-    "type": "local",
-    "command": ["executable", "arg1", "arg2"],
-    "enabled": true,
-    "environment": {
-      "VAR_NAME": "value"
-    }
-  }
-}
+```bash
+opencode mcp add              # interactive add
+opencode mcp list             # or `opencode mcp ls` — list servers + status
+opencode mcp auth <name>      # OAuth auth for remote servers
+opencode mcp auth list        # OAuth status for all servers
+opencode mcp logout <name>    # remove OAuth credentials
+opencode mcp debug <name>     # diagnose connection/OAuth issues
 ```
 
-| Field | Required | Description |
-|-------|----------|-------------|
-| `type` | Yes | Server type (local/remote) |
-| `command` | Yes | Command array to execute |
-| `enabled` | No | Enable/disable server (default: true) |
-| `environment` | No | Environment variables |
+OAuth tokens are stored in `~/.local/share/opencode/mcp-auth.json`.
 
 ## Environment Variables
 
@@ -222,20 +186,11 @@ Use variable substitution for secrets:
 
 ```json
 {
-  "$schema": "https://opencode.dev/schema/opencode.json",
+  "$schema": "https://opencode.ai/config.json",
   "mcp": {
-    "brave-search": {
-      "type": "local",
-      "command": ["npx", "-y", "@modelcontextprotocol/server-brave-search"],
-      "enabled": true,
-      "environment": {
-        "BRAVE_API_KEY": "{env:BRAVE_API_KEY}"
-      }
-    },
     "context7": {
-      "type": "local",
-      "command": ["npx", "-y", "@upstash/context7-mcp"],
-      "enabled": true
+      "type": "remote",
+      "url": "https://mcp.context7.com/mcp"
     },
     "github": {
       "type": "local",
@@ -265,14 +220,27 @@ Set `enabled: false` to disable without removing:
 }
 ```
 
+You can also disable MCP tools globally via `tools` globs (tools are registered with the server name as a prefix, e.g. `my-mcp*`):
+
+```json
+{
+  "mcp": {
+    "my-mcp": { "type": "local", "command": ["bun", "x", "my-mcp-command"] }
+  },
+  "tools": {
+    "my-mcp*": false
+  }
+}
+```
+
 ## Troubleshooting
 
 ### Server Not Loading
 
 1. Check `npx` is available
-2. Verify package name is correct
+2. Verify package name is correct (`npm view <package>`)
 3. Check environment variables are set
-4. Look at OpenCode logs for errors
+4. Run `opencode mcp list` / `opencode mcp debug <name>` and check logs
 
 ### Permission Errors
 

--- a/references/provider-config.md
+++ b/references/provider-config.md
@@ -24,19 +24,26 @@ OpenCode uses JSON/JSONC format with schema validation:
 
 ## File Locations
 
-Configs are merged in precedence order:
+Config files are **merged** (not replaced). Later sources override earlier ones for conflicting keys. Effective order (lowest to highest):
 
-1. `OPENCODE_CONFIG` environment variable (highest)
-2. `opencode.json` in project root
-3. `~/.config/opencode/opencode.json` (lowest)
+1. Remote organizational config (`.well-known/opencode`)
+2. Global: `~/.config/opencode/opencode.json`
+3. Custom path: `OPENCODE_CONFIG` env var
+4. Project: `opencode.json` in project root
+5. `.opencode/` directories
+6. Inline: `OPENCODE_CONFIG_CONTENT` env var
+
+In practice: project config overrides `OPENCODE_CONFIG` overrides global.
 
 ## Built-in Providers
+
+Most well-known providers (Anthropic, OpenAI, Google, etc.) need **no provider block** — just authenticate via `opencode auth login` or set the environment variable. OpenCode is powered by the provider list at models.dev.
 
 ### Anthropic
 
 ```json
 {
-  "model": "anthropic/claude-sonnet-4-20250514",
+  "model": "anthropic/claude-sonnet-4-5",
   "provider": {
     "anthropic": {
       "options": {
@@ -82,14 +89,6 @@ Configs are merged in precedence order:
 ```
 
 **Environment:** `GOOGLE_GENERATIVE_AI_API_KEY`
-
-### OpenCode Free Tier
-
-No configuration needed - use directly:
-
-```bash
-opencode run --model opencode/grok-code "Your prompt"
-```
 
 ## Custom Provider Setup
 
@@ -140,9 +139,6 @@ For providers with OpenAI-compatible endpoints:
       "models": {
         "llama3.2": {
           "name": "Llama 3.2 (local)"
-        },
-        "codellama": {
-          "name": "Code Llama (local)"
         }
       }
     }
@@ -213,6 +209,8 @@ Only allow specific providers:
 }
 ```
 
+If an environment variable is not set, it is replaced with an empty string.
+
 ### File References
 
 ```json
@@ -227,10 +225,7 @@ Only allow specific providers:
 }
 ```
 
-Supports:
-- Absolute paths: `/path/to/file`
-- Home directory: `~/path/to/file`
-- Relative paths: `./path/to/file` (relative to config directory)
+File paths can be relative to the config file directory, or absolute paths starting with `/` or `~`.
 
 ## Model Configuration
 
@@ -265,6 +260,26 @@ Configure a cheaper model for lightweight tasks:
 
 OpenCode automatically uses `small_model` for tasks like title generation.
 
+### Provider Options
+
+```json
+{
+  "provider": {
+    "anthropic": {
+      "options": {
+        "timeout": 600000,
+        "chunkTimeout": 30000,
+        "setCacheKey": true
+      }
+    }
+  }
+}
+```
+
+- `timeout` - Request timeout in ms (default 300000; set `false` to disable)
+- `chunkTimeout` - Timeout between streamed chunks
+- `setCacheKey` - Always set a cache key
+
 ## Authentication Methods
 
 ### API Key (Most Common)
@@ -279,10 +294,17 @@ OpenCode automatically uses `small_model` for tasks like title generation.
 
 ### AWS Bedrock
 
-```bash
-export AWS_ACCESS_KEY_ID="..."
-export AWS_SECRET_ACCESS_KEY="..."
-export AWS_REGION="us-east-1"
+```json
+{
+  "provider": {
+    "amazon-bedrock": {
+      "options": {
+        "region": "us-east-1",
+        "profile": "my-aws-profile"
+      }
+    }
+  }
+}
 ```
 
 ### Azure OpenAI
@@ -357,8 +379,7 @@ Multi-provider configuration:
         "baseURL": "http://localhost:11434/v1"
       },
       "models": {
-        "llama3.2": { "name": "Llama 3.2" },
-        "codellama": { "name": "Code Llama" }
+        "llama3.2": { "name": "Llama 3.2" }
       }
     }
   }
@@ -370,9 +391,7 @@ Multi-provider configuration:
 List available models after configuration:
 
 ```bash
-# In TUI mode
-opencode
-# Then type /models
+opencode models [provider]   # or: opencode models --refresh
 
 # Or test headless
 opencode run --model provider/model "Test prompt"

--- a/references/vertex-ai-setup.md
+++ b/references/vertex-ai-setup.md
@@ -1,12 +1,12 @@
 # Vertex AI Setup for OpenCode
 
-Configure OpenCode to use Google Cloud Vertex AI for access to Gemini and Claude models.
+Configure OpenCode to use Google Cloud Vertex AI for access to Gemini models (and Claude via the Anthropic Vertex SDK).
 
 ## Prerequisites
 
 1. Google Cloud project with Vertex AI API enabled
-2. Service account with Vertex AI User role (or equivalent)
-3. Service account JSON key file
+2. Service account with Vertex AI User role (`roles/aiplatform.user`)
+3. Service account JSON key file, or `gcloud` ADC
 4. OpenCode CLI installed
 
 ## Environment Variables
@@ -21,12 +21,7 @@ export GOOGLE_CLOUD_PROJECT="your-project-id"
 export GOOGLE_APPLICATION_CREDENTIALS="/path/to/service-account.json"
 # OR use gcloud CLI authentication:
 # gcloud auth application-default login
-
-# Optional - defaults to 'global'
-export VERTEX_LOCATION="us-central1"
 ```
-
-**Tip:** Use `global` for the location to improve availability without extra cost.
 
 ## Configuration File
 
@@ -43,7 +38,7 @@ Create `~/.config/opencode/opencode.json` or project-level `opencode.json`:
       "npm": "@ai-sdk/google-vertex",
       "options": {
         "project": "{env:GOOGLE_CLOUD_PROJECT}",
-        "location": "{env:VERTEX_LOCATION}"
+        "location": "us-central1"
       },
       "models": {
         "gemini-2.5-pro": {
@@ -68,7 +63,7 @@ Create `~/.config/opencode/opencode.json` or project-level `opencode.json`:
 
 ### Claude on Vertex AI
 
-Claude models on Vertex AI require a different SDK package:
+Claude models on Vertex AI use Anthropic's Vertex SDK package. Verify the current package name (e.g. `@ai-sdk/anthropic-vertex`) before relying on it:
 
 ```json
 {
@@ -76,7 +71,7 @@ Claude models on Vertex AI require a different SDK package:
   "model": "vertex-anthropic/claude-sonnet-4",
   "provider": {
     "vertex-anthropic": {
-      "npm": "@ai-sdk/google-vertex/anthropic",
+      "npm": "@ai-sdk/anthropic-vertex",
       "options": {
         "project": "{env:GOOGLE_CLOUD_PROJECT}",
         "location": "us-east5"
@@ -138,22 +133,7 @@ OpenCode supports environment variable substitution in config:
   "provider": {
     "google-vertex": {
       "options": {
-        "project": "{env:GOOGLE_CLOUD_PROJECT}",
-        "location": "{env:VERTEX_LOCATION}"
-      }
-    }
-  }
-}
-```
-
-Also supports file references:
-
-```json
-{
-  "provider": {
-    "google-vertex": {
-      "options": {
-        "credentials": "{file:~/.secrets/vertex-credentials.json}"
+        "project": "{env:GOOGLE_CLOUD_PROJECT}"
       }
     }
   }
@@ -162,21 +142,10 @@ Also supports file references:
 
 ## Available Vertex AI Models
 
-### Gemini Models
-
 | Model ID | Description |
 |----------|-------------|
 | `gemini-2.5-pro` | Most capable Gemini model |
 | `gemini-2.5-flash` | Fast, efficient for simple tasks |
-| `gemini-2.0-flash-exp` | Experimental flash model |
-
-### Claude Models (via Vertex)
-
-| Model ID | Description |
-|----------|-------------|
-| `claude-sonnet-4` | Balanced performance |
-| `claude-opus-4` | Most capable Claude |
-| `claude-haiku-4` | Fast, cost-effective |
 
 ## Verification
 
@@ -186,6 +155,9 @@ Test the configuration:
 # Set environment
 export GOOGLE_CLOUD_PROJECT="your-project"
 export GOOGLE_APPLICATION_CREDENTIALS="/path/to/key.json"
+
+# List available vertex models
+opencode models google-vertex
 
 # Test with a simple prompt
 opencode run --model google-vertex/gemini-2.5-flash "Hello, respond with OK"
@@ -223,7 +195,7 @@ Error: Model not available in region
 Error: Model 'xyz' not found
 ```
 
-**Fix:** Verify the model ID matches Vertex AI naming. Use the `/models` command in OpenCode TUI to see available models.
+**Fix:** Verify the model ID matches Vertex AI naming. Use `opencode models google-vertex` to see available models.
 
 ## Cost Considerations
 


### PR DESCRIPTION
## Summary

Updates the skill's documented facts to match the current OpenCode CLI (https://opencode.ai/docs), verified as of Aug 2026.

## Corrections

- **Runtime**: OpenCode is TypeScript/Bun, not Go-based (SKILL.md, README).
- **Config precedence**: project `opencode.json` overrides `OPENCODE_CONFIG` overrides global — the previous order was inverted.
- **Schema URLs**: standardized on `https://opencode.ai/config.json` (was `opencode.dev/schema/opencode.json`).
- **MCP packages**: replaced deprecated `@anthropic-ai/mcp-server-*` with `@modelcontextprotocol/server-*`; prefer remote Context7 server.
- **Permissions**: documented `permission` config + `run --auto` (the old "no tool pre-approval" claim is wrong).
- **Run flags**: added `--format json`, `-c`/`-s` session continuation, `--auto`, `--file`, `--attach`, and the `serve` warm-start pattern.
- **Auth**: added `opencode auth login` and the `~/.local/share/opencode/auth.json` location.
- **CLI mgmt**: added `opencode models`, `opencode mcp list/auth/logout/debug`.
- **Vertex AI**: corrected the Claude-on-Vertex SDK package note; removed non-standard `VERTEX_LOCATION`; use `opencode models` instead of the `/models` TUI command.

## Files changed

- README.md
- SKILL.md
- references/provider-config.md
- references/vertex-ai-setup.md
- references/mcp-servers.md
- references/local-models.md
- references/cloud-providers.md
- references/integration-patterns.md
